### PR TITLE
Add PHPUnit tests for core plugin classes (59 tests)

### DIFF
--- a/tests/courseskills_test.php
+++ b/tests/courseskills_test.php
@@ -60,6 +60,11 @@ final class courseskills_test extends \advanced_testcase {
         ]);
     }
 
+    /**
+     * Insert a minimal skill level record and return its id.
+     *
+     * @return int
+     */
     private function create_level(int $skillid, int $points): int {
         global $DB;
         return $DB->insert_record('tool_skills_levels', (object)[
@@ -103,10 +108,6 @@ final class courseskills_test extends \advanced_testcase {
         $cinfo->mark_course_completions([$user->id]);
     }
 
-    // -------------------------------------------------------------------------
-    // Instance skill lists
-    // -------------------------------------------------------------------------
-
     /**
      * Test get_instance_skills() returns only enabled skills for the course.
      */
@@ -137,10 +138,6 @@ final class courseskills_test extends \advanced_testcase {
         $this->assertCount(1, $result);
     }
 
-    // -------------------------------------------------------------------------
-    // remove_instance_skills
-    // -------------------------------------------------------------------------
-
     /**
      * Test remove_instance_skills() clears all skill assignments for a course.
      */
@@ -157,10 +154,6 @@ final class courseskills_test extends \advanced_testcase {
         $this->assertEquals(0, $DB->count_records('tool_skills_courses', ['courseid' => $course->id]));
     }
 
-    // -------------------------------------------------------------------------
-    // manage_course_completions
-    // -------------------------------------------------------------------------
-
     /**
      * Test COMPLETIONPOINTS strategy awards the configured points when course is completed.
      */
@@ -174,6 +167,7 @@ final class courseskills_test extends \advanced_testcase {
 
         $cs = courseskills::get($course->id);
         $skills = $cs->get_instance_skills();
+        $this->complete_course($course, $user);
         $cs->manage_course_completions($user->id, $skills, null);
 
         $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
@@ -193,6 +187,7 @@ final class courseskills_test extends \advanced_testcase {
         $this->assign_skill_to_course($course->id, $skillid, 1, skills::COMPLETIONSETLEVEL, 0, $levelid);
 
         $cs = courseskills::get($course->id);
+        $this->complete_course($course, $user);
         $cs->manage_course_completions($user->id, $cs->get_instance_skills(), null);
 
         $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
@@ -219,6 +214,7 @@ final class courseskills_test extends \advanced_testcase {
         $this->assign_skill_to_course($course->id, $skillid, 1, skills::COMPLETIONFORCELEVEL, 0, $levelid);
 
         $cs = courseskills::get($course->id);
+        $this->complete_course($course, $user);
         $cs->manage_course_completions($user->id, $cs->get_instance_skills(), null);
 
         $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
@@ -241,10 +237,6 @@ final class courseskills_test extends \advanced_testcase {
 
         $this->assertFalse($DB->record_exists('tool_skills_userpoints', ['skill' => $skillid, 'userid' => $user->id]));
     }
-
-    // -------------------------------------------------------------------------
-    // Static helpers
-    // -------------------------------------------------------------------------
 
     /**
      * Test get_for_skill() returns all courses that have the skill assigned.
@@ -277,10 +269,6 @@ final class courseskills_test extends \advanced_testcase {
 
         $this->assertEquals(0, $DB->count_records('tool_skills_courses', ['skill' => $skillid]));
     }
-
-    // -------------------------------------------------------------------------
-    // get_points_earned_fromcourse
-    // -------------------------------------------------------------------------
 
     /**
      * Test get_points_earned_fromcourse() returns the configured points for COMPLETIONPOINTS.

--- a/tests/courseskills_test.php
+++ b/tests/courseskills_test.php
@@ -1,0 +1,297 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tool Skills - PHPUnit tests for the courseskills class.
+ *
+ * @package   tool_skills
+ * @copyright 2023 bdecent GmbH <https://bdecent.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_skills;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for \tool_skills\courseskills.
+ *
+ * @covers \tool_skills\courseskills
+ */
+final class courseskills_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+    }
+
+    private function create_skill(): int {
+        global $DB;
+        static $n = 0;
+        $n++;
+        return $DB->insert_record('tool_skills', (object)[
+            'name'         => 'Skill ' . $n,
+            'identitykey'  => 'csk' . $n,
+            'description'  => '',
+            'status'       => 1,
+            'categories'   => '[]',
+            'learningtime' => '',
+            'levelscount'  => 0,
+            'archived'     => 0,
+            'timearchived' => 0,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    private function create_level(int $skillid, int $points): int {
+        global $DB;
+        return $DB->insert_record('tool_skills_levels', (object)[
+            'skill'        => $skillid,
+            'name'         => 'L' . $points,
+            'points'       => $points,
+            'status'       => 1,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    /**
+     * Insert a tool_skills_courses record and return its id.
+     */
+    private function assign_skill_to_course(
+        int $courseid,
+        int $skillid,
+        int $status = 1,
+        int $uponcompletion = 1,
+        int $points = 50,
+        int $level = 0
+    ): int {
+        global $DB;
+        return $DB->insert_record('tool_skills_courses', (object)[
+            'courseid'       => $courseid,
+            'skill'          => $skillid,
+            'status'         => $status,
+            'uponcompletion' => $uponcompletion,
+            'points'         => $points,
+            'level'          => $level,
+            'timemodified'   => time(),
+        ]);
+    }
+
+    /**
+     * Mark a course complete for a user via the completion API.
+     */
+    private function complete_course(\stdClass $course, \stdClass $user): void {
+        $cinfo = new \completion_info($course);
+        $cinfo->mark_course_completions([$user->id]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Instance skill lists
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test get_instance_skills() returns only enabled skills for the course.
+     */
+    public function test_get_instance_skills_returns_enabled_skills(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $skill1 = $this->create_skill();
+        $skill2 = $this->create_skill();
+        $skill3 = $this->create_skill();
+        $this->assign_skill_to_course($course->id, $skill1, 1);
+        $this->assign_skill_to_course($course->id, $skill2, 1);
+        $this->assign_skill_to_course($course->id, $skill3, 0); // disabled
+
+        $result = courseskills::get($course->id)->get_instance_skills();
+        $this->assertCount(2, $result);
+    }
+
+    /**
+     * Test get_instance_disabled_skills() returns only disabled skills for the course.
+     */
+    public function test_get_instance_disabled_skills_returns_disabled_only(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $skill1 = $this->create_skill();
+        $skill2 = $this->create_skill();
+        $this->assign_skill_to_course($course->id, $skill1, 1);
+        $this->assign_skill_to_course($course->id, $skill2, 0);
+
+        $result = courseskills::get($course->id)->get_instance_disabled_skills();
+        $this->assertCount(1, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // remove_instance_skills
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test remove_instance_skills() clears all skill assignments for a course.
+     */
+    public function test_remove_instance_skills_clears_course_skills(): void {
+        global $DB;
+        $course = $this->getDataGenerator()->create_course();
+        $skill1 = $this->create_skill();
+        $skill2 = $this->create_skill();
+        $this->assign_skill_to_course($course->id, $skill1);
+        $this->assign_skill_to_course($course->id, $skill2);
+
+        courseskills::get($course->id)->remove_instance_skills();
+
+        $this->assertEquals(0, $DB->count_records('tool_skills_courses', ['courseid' => $course->id]));
+    }
+
+    // -------------------------------------------------------------------------
+    // manage_course_completions
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test COMPLETIONPOINTS strategy awards the configured points when course is completed.
+     */
+    public function test_manage_course_completions_awards_points_on_completion(): void {
+        global $DB;
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user   = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+        $skillid = $this->create_skill();
+        $this->assign_skill_to_course($course->id, $skillid, 1, skills::COMPLETIONPOINTS, 50);
+
+        $cs = courseskills::get($course->id);
+        $skills = $cs->get_instance_skills();
+        $cs->manage_course_completions($user->id, $skills, null);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(50, $points);
+    }
+
+    /**
+     * Test COMPLETIONSETLEVEL strategy awards exactly the level's threshold points.
+     */
+    public function test_manage_course_completions_set_level_awards_level_points(): void {
+        global $DB;
+        $course  = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user    = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+        $skillid = $this->create_skill();
+        $levelid = $this->create_level($skillid, 80);
+        $this->assign_skill_to_course($course->id, $skillid, 1, skills::COMPLETIONSETLEVEL, 0, $levelid);
+
+        $cs = courseskills::get($course->id);
+        $cs->manage_course_completions($user->id, $cs->get_instance_skills(), null);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(80, $points);
+    }
+
+    /**
+     * Test COMPLETIONFORCELEVEL strategy overwrites user points with the level threshold.
+     */
+    public function test_manage_course_completions_force_level_overwrites_points(): void {
+        global $DB;
+        $course  = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user    = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+        $skillid = $this->create_skill();
+        $levelid = $this->create_level($skillid, 80);
+
+        // Pre-award 200 pts so user is above the level.
+        $DB->insert_record('tool_skills_userpoints', (object)[
+            'skill' => $skillid, 'userid' => $user->id, 'points' => 200,
+            'timecreated' => time(), 'timemodified' => time(),
+        ]);
+
+        $this->assign_skill_to_course($course->id, $skillid, 1, skills::COMPLETIONFORCELEVEL, 0, $levelid);
+
+        $cs = courseskills::get($course->id);
+        $cs->manage_course_completions($user->id, $cs->get_instance_skills(), null);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(80, $points);
+    }
+
+    /**
+     * Test COMPLETIONNOTHING strategy creates no userpoints record.
+     */
+    public function test_manage_course_completions_nothing_awards_zero_points(): void {
+        global $DB;
+        $course  = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $user    = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+        $skillid = $this->create_skill();
+        $this->assign_skill_to_course($course->id, $skillid, 1, skills::COMPLETIONNOTHING, 0);
+
+        $cs = courseskills::get($course->id);
+        $cs->manage_course_completions($user->id, $cs->get_instance_skills(), null);
+
+        $this->assertFalse($DB->record_exists('tool_skills_userpoints', ['skill' => $skillid, 'userid' => $user->id]));
+    }
+
+    // -------------------------------------------------------------------------
+    // Static helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test get_for_skill() returns all courses that have the skill assigned.
+     */
+    public function test_get_for_skill_returns_all_courses_with_skill(): void {
+        $skillid = $this->create_skill();
+        $c1 = $this->getDataGenerator()->create_course();
+        $c2 = $this->getDataGenerator()->create_course();
+        $c3 = $this->getDataGenerator()->create_course();
+        $this->assign_skill_to_course($c1->id, $skillid);
+        $this->assign_skill_to_course($c2->id, $skillid);
+        $this->assign_skill_to_course($c3->id, $skillid);
+
+        $result = courseskills::get_for_skill($skillid);
+        $this->assertCount(3, $result);
+    }
+
+    /**
+     * Test remove_skills() removes a skill from all courses.
+     */
+    public function test_remove_skills_removes_from_all_courses(): void {
+        global $DB;
+        $skillid = $this->create_skill();
+        $c1 = $this->getDataGenerator()->create_course();
+        $c2 = $this->getDataGenerator()->create_course();
+        $this->assign_skill_to_course($c1->id, $skillid);
+        $this->assign_skill_to_course($c2->id, $skillid);
+
+        courseskills::remove_skills($skillid);
+
+        $this->assertEquals(0, $DB->count_records('tool_skills_courses', ['skill' => $skillid]));
+    }
+
+    // -------------------------------------------------------------------------
+    // get_points_earned_fromcourse
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test get_points_earned_fromcourse() returns the configured points for COMPLETIONPOINTS.
+     */
+    public function test_get_points_earned_fromcourse_returns_configured_points(): void {
+        $course  = $this->getDataGenerator()->create_course();
+        $skillid = $this->create_skill();
+        $instanceid = $this->assign_skill_to_course($course->id, $skillid, 1, skills::COMPLETIONPOINTS, 75);
+
+        $cs = courseskills::get($course->id);
+        $cs->set_skill_instance($instanceid);
+        $result = $cs->get_points_earned_fromcourse();
+
+        $this->assertEquals(75, $result);
+    }
+}

--- a/tests/courseskills_test.php
+++ b/tests/courseskills_test.php
@@ -24,21 +24,23 @@
 
 namespace tool_skills;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Unit tests for \tool_skills\courseskills.
  *
  * @covers \tool_skills\courseskills
  */
 final class courseskills_test extends \advanced_testcase {
-
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
         $this->setAdminUser();
     }
 
+    /**
+     * Insert a minimal skill record and return its id.
+     *
+     * @return int
+     */
     private function create_skill(): int {
         global $DB;
         static $n = 0;

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -1,0 +1,154 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tool Skills - PHPUnit tests for the helper class.
+ *
+ * @package   tool_skills
+ * @copyright 2023 bdecent GmbH <https://bdecent.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_skills;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for \tool_skills\helper.
+ *
+ * @covers \tool_skills\helper
+ */
+final class helper_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    private function create_skill(int $points = 0): int {
+        global $DB;
+        static $n = 0;
+        $n++;
+        return $DB->insert_record('tool_skills', (object)[
+            'name'         => 'Skill ' . $n,
+            'identitykey'  => 'hsk' . $n,
+            'description'  => '',
+            'status'       => 1,
+            'categories'   => '[]',
+            'learningtime' => '',
+            'levelscount'  => 0,
+            'archived'     => 0,
+            'timearchived' => 0,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    private function create_level(int $skillid, int $points): int {
+        global $DB;
+        return $DB->insert_record('tool_skills_levels', (object)[
+            'skill'        => $skillid,
+            'name'         => 'L' . $points,
+            'points'       => $points,
+            'status'       => 1,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    private function insert_userpoints(int $skillid, int $userid, int $points): void {
+        global $DB;
+        $DB->insert_record('tool_skills_userpoints', (object)[
+            'skill'        => $skillid,
+            'userid'       => $userid,
+            'points'       => $points,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    private function create_courseskill(int $courseid, int $skillid, int $levelpoints): int {
+        global $DB;
+        $levelid = $this->create_level($skillid, $levelpoints);
+        return $DB->insert_record('tool_skills_courses', (object)[
+            'courseid'       => $courseid,
+            'skill'          => $skillid,
+            'status'         => 1,
+            'uponcompletion' => skills::COMPLETIONFORCELEVEL,
+            'points'         => 0,
+            'level'          => $levelid,
+            'timemodified'   => time(),
+        ]);
+    }
+
+    /**
+     * Test get_skills_list() returns all skills as skills instances.
+     */
+    public function test_get_skills_list_returns_all_skills(): void {
+        $this->create_skill();
+        $this->create_skill();
+        $this->create_skill();
+
+        $list = helper::get_skills_list();
+        $this->assertCount(3, $list);
+        foreach ($list as $skill) {
+            $this->assertInstanceOf(skills::class, $skill);
+        }
+    }
+
+    /**
+     * Test get_user_completedskills() returns skills the user has fully completed (100%).
+     */
+    public function test_get_user_completedskills_returns_completed_skills(): void {
+        $user    = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->create_level($skillid, 100); // max = 100 pts
+        $this->insert_userpoints($skillid, $user->id, 100);
+
+        $result = helper::get_user_completedskills($user->id);
+        $this->assertNotEmpty($result);
+        $this->assertContains($skillid, $result);
+    }
+
+    /**
+     * Test get_user_completedskills() excludes skills where the user has not reached 100%.
+     */
+    public function test_get_user_completedskills_excludes_incomplete(): void {
+        $user    = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->create_level($skillid, 100);
+        $this->insert_userpoints($skillid, $user->id, 50); // only 50%
+
+        $result = helper::get_user_completedskills($user->id);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test get_courses_skill_points() sums max level points across all given courses.
+     */
+    public function test_get_courses_skill_points_sums_correctly(): void {
+        $course1 = $this->getDataGenerator()->create_course();
+        $course2 = $this->getDataGenerator()->create_course();
+        $skill1  = $this->create_skill();
+        $skill2  = $this->create_skill();
+
+        $this->create_courseskill($course1->id, $skill1, 100);
+        $this->create_courseskill($course2->id, $skill2, 50);
+
+        $total = helper::get_courses_skill_points([$course1->id, $course2->id]);
+        $this->assertEquals(150, $total);
+    }
+}

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -24,20 +24,20 @@
 
 namespace tool_skills;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Unit tests for \tool_skills\helper.
  *
  * @covers \tool_skills\helper
  */
 final class helper_test extends \advanced_testcase {
-
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
     }
 
+    /**
+     * Create the DB fixtures needed by most tests.
+     */
     private function create_skill(int $points = 0): int {
         global $DB;
         static $n = 0;
@@ -115,7 +115,7 @@ final class helper_test extends \advanced_testcase {
     public function test_get_user_completedskills_returns_completed_skills(): void {
         $user    = $this->getDataGenerator()->create_user();
         $skillid = $this->create_skill();
-        $this->create_level($skillid, 100); // max = 100 pts
+        $this->create_level($skillid, 100); // Max = 100 pts.
         $this->insert_userpoints($skillid, $user->id, 100);
 
         $result = helper::get_user_completedskills($user->id);
@@ -130,7 +130,7 @@ final class helper_test extends \advanced_testcase {
         $user    = $this->getDataGenerator()->create_user();
         $skillid = $this->create_skill();
         $this->create_level($skillid, 100);
-        $this->insert_userpoints($skillid, $user->id, 50); // only 50%
+        $this->insert_userpoints($skillid, $user->id, 50); // Only 50%.
 
         $result = helper::get_user_completedskills($user->id);
         $this->assertEmpty($result);

--- a/tests/level_test.php
+++ b/tests/level_test.php
@@ -24,15 +24,12 @@
 
 namespace tool_skills;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Unit tests for \tool_skills\level.
  *
  * @covers \tool_skills\level
  */
 final class level_test extends \advanced_testcase {
-
     /** @var int Reusable skill id. */
     private int $skillid;
 
@@ -43,6 +40,11 @@ final class level_test extends \advanced_testcase {
         $this->skillid = $this->create_skill();
     }
 
+    /**
+     * Insert a minimal skill record and return its id.
+     *
+     * @return int
+     */
     private function create_skill(): int {
         global $DB;
         static $counter = 0;
@@ -62,6 +64,13 @@ final class level_test extends \advanced_testcase {
         ]);
     }
 
+    /**
+     * Insert a level for the given skill and return its id.
+     *
+     * @param int $skillid
+     * @param int $points
+     * @return int
+     */
     private function create_level(int $skillid, int $points = 100): int {
         global $DB;
         return $DB->insert_record('tool_skills_levels', (object)[
@@ -101,7 +110,7 @@ final class level_test extends \advanced_testcase {
         global $DB;
         $skill = skills::get($this->skillid);
         $levels = [
-            1 => ['name' => 'Bronze', 'points' => 50,  'status' => 1, 'color' => ''],
+            1 => ['name' => 'Bronze', 'points' => 50, 'status' => 1, 'color' => ''],
             2 => ['name' => 'Silver', 'points' => 100, 'status' => 1, 'color' => ''],
         ];
         level::manage_level_instance($skill, $levels);

--- a/tests/level_test.php
+++ b/tests/level_test.php
@@ -1,0 +1,150 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tool Skills - PHPUnit tests for the level class.
+ *
+ * @package   tool_skills
+ * @copyright 2023 bdecent GmbH <https://bdecent.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_skills;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for \tool_skills\level.
+ *
+ * @covers \tool_skills\level
+ */
+final class level_test extends \advanced_testcase {
+
+    /** @var int Reusable skill id. */
+    private int $skillid;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $this->skillid = $this->create_skill();
+    }
+
+    private function create_skill(): int {
+        global $DB;
+        static $counter = 0;
+        $counter++;
+        return $DB->insert_record('tool_skills', (object)[
+            'name'         => 'Skill ' . $counter,
+            'identitykey'  => 'sk' . $counter,
+            'description'  => '',
+            'status'       => 1,
+            'categories'   => '[]',
+            'learningtime' => '',
+            'levelscount'  => 0,
+            'archived'     => 0,
+            'timearchived' => 0,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    private function create_level(int $skillid, int $points = 100): int {
+        global $DB;
+        return $DB->insert_record('tool_skills_levels', (object)[
+            'skill'        => $skillid,
+            'name'         => 'Level ' . $points,
+            'points'       => $points,
+            'status'       => 1,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    /**
+     * Test level::get() returns a level instance with the correct points value.
+     */
+    public function test_get_returns_level_instance(): void {
+        $levelid = $this->create_level($this->skillid, 75);
+        $level = level::get($levelid);
+        $this->assertInstanceOf(level::class, $level);
+        $this->assertEquals(75, $level->get_points());
+    }
+
+    /**
+     * Test delete_level() removes the record from the database.
+     */
+    public function test_delete_level_removes_from_db(): void {
+        global $DB;
+        $levelid = $this->create_level($this->skillid);
+        level::get($levelid)->delete_level();
+        $this->assertFalse($DB->record_exists('tool_skills_levels', ['id' => $levelid]));
+    }
+
+    /**
+     * Test manage_level_instance() creates new level records for a skill.
+     */
+    public function test_manage_level_instance_creates_new_levels(): void {
+        global $DB;
+        $skill = skills::get($this->skillid);
+        $levels = [
+            1 => ['name' => 'Bronze', 'points' => 50,  'status' => 1, 'color' => ''],
+            2 => ['name' => 'Silver', 'points' => 100, 'status' => 1, 'color' => ''],
+        ];
+        level::manage_level_instance($skill, $levels);
+        $this->assertEquals(2, $DB->count_records('tool_skills_levels', ['skill' => $this->skillid]));
+    }
+
+    /**
+     * Test manage_level_instance() updates an existing level without creating a duplicate.
+     */
+    public function test_manage_level_instance_updates_existing_levels(): void {
+        global $DB;
+        $skill = skills::get($this->skillid);
+        $levelid = $this->create_level($this->skillid, 50);
+
+        $levels = [
+            1 => ['id' => $levelid, 'name' => 'Updated', 'points' => 60, 'status' => 1, 'color' => ''],
+        ];
+        level::manage_level_instance($skill, $levels);
+
+        $this->assertEquals(1, $DB->count_records('tool_skills_levels', ['skill' => $this->skillid]));
+        $this->assertEquals(60, $DB->get_field('tool_skills_levels', 'points', ['id' => $levelid]));
+    }
+
+    /**
+     * Test manage_level_instance() returns false when given an empty levels array.
+     */
+    public function test_manage_level_instance_returns_false_for_empty_levels(): void {
+        $skill = skills::get($this->skillid);
+        $result = level::manage_level_instance($skill, []);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test remove_skill_levels() deletes all levels belonging to a skill.
+     */
+    public function test_remove_skill_levels_deletes_all_levels(): void {
+        global $DB;
+        $this->create_level($this->skillid, 30);
+        $this->create_level($this->skillid, 60);
+        $this->create_level($this->skillid, 90);
+
+        level::remove_skill_levels($this->skillid);
+
+        $this->assertEquals(0, $DB->count_records('tool_skills_levels', ['skill' => $this->skillid]));
+    }
+}

--- a/tests/logs_test.php
+++ b/tests/logs_test.php
@@ -24,20 +24,27 @@
 
 namespace tool_skills;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Unit tests for \tool_skills\logs.
  *
  * @covers \tool_skills\logs
  */
 final class logs_test extends \advanced_testcase {
-
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
     }
 
+    /**
+     * Insert a raw award log record and return its id.
+     *
+     * @param int $skillid
+     * @param int $userid
+     * @param int $points
+     * @param int $methodid
+     * @param string $method
+     * @return int
+     */
     private function insert_log(int $skillid, int $userid, int $points, int $methodid, string $method = 'course'): int {
         global $DB;
         return $DB->insert_record('tool_skills_awardlogs', (object)[

--- a/tests/logs_test.php
+++ b/tests/logs_test.php
@@ -1,0 +1,134 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tool Skills - PHPUnit tests for the logs class.
+ *
+ * @package   tool_skills
+ * @copyright 2023 bdecent GmbH <https://bdecent.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_skills;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for \tool_skills\logs.
+ *
+ * @covers \tool_skills\logs
+ */
+final class logs_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    private function insert_log(int $skillid, int $userid, int $points, int $methodid, string $method = 'course'): int {
+        global $DB;
+        return $DB->insert_record('tool_skills_awardlogs', (object)[
+            'skill'       => $skillid,
+            'userid'      => $userid,
+            'points'      => $points,
+            'methodid'    => $methodid,
+            'method'      => $method,
+            'timecreated' => time(),
+        ]);
+    }
+
+    /**
+     * Test add() creates a new log entry in tool_skills_awardlogs.
+     */
+    public function test_add_creates_log_entry(): void {
+        global $DB;
+        $user = $this->getDataGenerator()->create_user();
+        logs::get()->add(1, $user->id, 50, 10, 'course');
+        $this->assertTrue($DB->record_exists('tool_skills_awardlogs', [
+            'skill' => 1, 'userid' => $user->id, 'methodid' => 10, 'method' => 'course',
+        ]));
+    }
+
+    /**
+     * Test add() updates an existing log entry instead of creating a duplicate.
+     */
+    public function test_add_updates_existing_log_entry(): void {
+        global $DB;
+        $user = $this->getDataGenerator()->create_user();
+        logs::get()->add(1, $user->id, 50, 10, 'course');
+        logs::get()->add(1, $user->id, 80, 10, 'course');
+
+        $this->assertEquals(1, $DB->count_records('tool_skills_awardlogs', [
+            'skill' => 1, 'userid' => $user->id, 'methodid' => 10, 'method' => 'course',
+        ]));
+        $points = $DB->get_field('tool_skills_awardlogs', 'points', [
+            'skill' => 1, 'userid' => $user->id, 'methodid' => 10, 'method' => 'course',
+        ]);
+        $this->assertEquals(80, $points);
+    }
+
+    /**
+     * Test get_log() returns the matching stdClass record.
+     */
+    public function test_get_log_returns_existing_record(): void {
+        $user = $this->getDataGenerator()->create_user();
+        $this->insert_log(2, $user->id, 40, 5, 'course');
+
+        $log = logs::get()->get_log(2, $user->id, 5, 'course');
+        $this->assertIsObject($log);
+        $this->assertEquals(40, $log->points);
+    }
+
+    /**
+     * Test get_log() returns false when no matching record exists.
+     */
+    public function test_get_log_returns_false_when_not_found(): void {
+        $user = $this->getDataGenerator()->create_user();
+        $result = logs::get()->get_log(999, $user->id, 999, 'course');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test delete_user_log() removes only the target user's log entries.
+     */
+    public function test_delete_user_log_removes_only_target_user(): void {
+        global $DB;
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $this->insert_log(1, $user1->id, 50, 1);
+        $this->insert_log(1, $user2->id, 50, 1);
+
+        logs::get()->delete_user_log($user1->id);
+
+        $this->assertFalse($DB->record_exists('tool_skills_awardlogs', ['userid' => $user1->id]));
+        $this->assertTrue($DB->record_exists('tool_skills_awardlogs', ['userid' => $user2->id]));
+    }
+
+    /**
+     * Test delete_method_log() removes only logs for the specified method/methodid.
+     */
+    public function test_delete_method_log_removes_course_logs(): void {
+        global $DB;
+        $user = $this->getDataGenerator()->create_user();
+        $this->insert_log(1, $user->id, 50, 10, 'course');
+        $this->insert_log(1, $user->id, 30, 20, 'mod');
+
+        logs::get()->delete_method_log(10, 'course');
+
+        $this->assertFalse($DB->record_exists('tool_skills_awardlogs', ['methodid' => 10, 'method' => 'course']));
+        $this->assertTrue($DB->record_exists('tool_skills_awardlogs', ['methodid' => 20, 'method' => 'mod']));
+    }
+}

--- a/tests/privacy_test.php
+++ b/tests/privacy_test.php
@@ -1,0 +1,215 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tool Skills - PHPUnit tests for the privacy provider.
+ *
+ * @package   tool_skills
+ * @copyright 2023 bdecent GmbH <https://bdecent.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_skills;
+
+defined('MOODLE_INTERNAL') || die();
+
+use core_privacy\local\metadata\collection;
+use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\approved_userlist;
+use core_privacy\local\request\userlist;
+use core_privacy\local\request\writer;
+use tool_skills\privacy\provider;
+
+/**
+ * Unit tests for \tool_skills\privacy\provider.
+ *
+ * @covers \tool_skills\privacy\provider
+ */
+final class privacy_test extends \core_privacy\tests\provider_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    /**
+     * Build the DB fixtures needed by most tests:
+     *   - A course
+     *   - A skill
+     *   - A tool_skills_courses record linking them
+     *   - A tool_skills_userpoints record
+     *   - A tool_skills_awardlogs record
+     *
+     * Returns an object with properties: course, skill, user, courseskillid.
+     */
+    private function create_full_fixture(\stdClass $user = null): \stdClass {
+        global $DB;
+
+        if ($user === null) {
+            $user = $this->getDataGenerator()->create_user();
+        }
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        // Create skill.
+        $skillid = $DB->insert_record('tool_skills', (object)[
+            'name'         => 'Privacy Skill',
+            'identitykey'  => 'privsk' . rand(1, 9999),
+            'description'  => '',
+            'status'       => 1,
+            'categories'   => '[]',
+            'learningtime' => '',
+            'levelscount'  => 0,
+            'archived'     => 0,
+            'timearchived' => 0,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+
+        // Link skill to course.
+        $courseskillid = $DB->insert_record('tool_skills_courses', (object)[
+            'courseid'       => $course->id,
+            'skill'          => $skillid,
+            'status'         => 1,
+            'uponcompletion' => skills::COMPLETIONPOINTS,
+            'points'         => 50,
+            'level'          => 0,
+            'timemodified'   => time(),
+        ]);
+
+        // Insert user points.
+        $DB->insert_record('tool_skills_userpoints', (object)[
+            'skill'        => $skillid,
+            'userid'       => $user->id,
+            'points'       => 50,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+
+        // Insert award log referencing the tool_skills_courses record id.
+        $DB->insert_record('tool_skills_awardlogs', (object)[
+            'skill'       => $skillid,
+            'userid'      => $user->id,
+            'points'      => 50,
+            'methodid'    => $courseskillid,
+            'method'      => 'course',
+            'timecreated' => time(),
+        ]);
+
+        $result = new \stdClass();
+        $result->course       = $course;
+        $result->skillid      = $skillid;
+        $result->user         = $user;
+        $result->courseskillid = $courseskillid;
+        return $result;
+    }
+
+    /**
+     * Test get_metadata() declares both userpoints and awardlogs tables.
+     */
+    public function test_get_metadata_describes_userpoints_and_awardlogs(): void {
+        $collection = new collection('tool_skills');
+        $result = provider::get_metadata($collection);
+
+        $this->assertInstanceOf(collection::class, $result);
+        // Inspect the items by iterating and collecting table names.
+        $tablenames = [];
+        foreach ($result->get_collection() as $item) {
+            if ($item instanceof \core_privacy\local\metadata\types\database_table) {
+                $tablenames[] = $item->get_name();
+            }
+        }
+        $this->assertContains('tool_skills_userpoints', $tablenames);
+        $this->assertContains('tool_skills_awardlogs', $tablenames);
+    }
+
+    /**
+     * Test get_contexts_for_userid() returns the course context when the user has award data.
+     */
+    public function test_get_contexts_for_userid_returns_course_context(): void {
+        $fixture = $this->create_full_fixture();
+        $coursecontext = \context_course::instance($fixture->course->id);
+
+        $contextlist = provider::get_contexts_for_userid($fixture->user->id);
+        $contextids  = $contextlist->get_contextids();
+
+        $this->assertContains((string) $coursecontext->id, $contextids);
+    }
+
+    /**
+     * Test get_contexts_for_userid() returns empty list when user has no data.
+     */
+    public function test_get_contexts_for_userid_returns_empty_for_unknown_user(): void {
+        $user = $this->getDataGenerator()->create_user();
+        $contextlist = provider::get_contexts_for_userid($user->id);
+        $this->assertCount(0, $contextlist);
+    }
+
+    /**
+     * Test delete_data_for_user() removes both userpoints and awardlogs for the user.
+     */
+    public function test_delete_data_for_user_removes_all_user_records(): void {
+        global $DB;
+        $fixture = $this->create_full_fixture();
+        $coursecontext = \context_course::instance($fixture->course->id);
+
+        // Build approved contextlist.
+        $approvedcontextlist = new approved_contextlist(
+            $fixture->user,
+            'tool_skills',
+            [$coursecontext->id]
+        );
+
+        provider::delete_data_for_user($approvedcontextlist);
+
+        $this->assertFalse($DB->record_exists('tool_skills_userpoints', ['userid' => $fixture->user->id]));
+        $this->assertFalse($DB->record_exists('tool_skills_awardlogs', ['userid' => $fixture->user->id]));
+    }
+
+    /**
+     * Test delete_data_for_all_users_in_context() adjusts points for all users in a course context.
+     */
+    public function test_delete_data_for_all_users_in_context_clears_course_logs(): void {
+        global $DB;
+        $user1    = $this->getDataGenerator()->create_user();
+        $user2    = $this->getDataGenerator()->create_user();
+        $fixture1 = $this->create_full_fixture($user1);
+        // Second user in the same course/skill.
+        $DB->insert_record('tool_skills_userpoints', (object)[
+            'skill'        => $fixture1->skillid,
+            'userid'       => $user2->id,
+            'points'       => 50,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+        $DB->insert_record('tool_skills_awardlogs', (object)[
+            'skill'       => $fixture1->skillid,
+            'userid'      => $user2->id,
+            'points'      => 50,
+            'methodid'    => $fixture1->courseskillid,
+            'method'      => 'course',
+            'timecreated' => time(),
+        ]);
+
+        $coursecontext = \context_course::instance($fixture1->course->id);
+        provider::delete_data_for_all_users_in_context($coursecontext);
+
+        // Award logs for the course method should be gone.
+        $this->assertFalse($DB->record_exists('tool_skills_awardlogs', [
+            'methodid' => $fixture1->courseskillid, 'method' => 'course',
+        ]));
+    }
+}

--- a/tests/privacy_test.php
+++ b/tests/privacy_test.php
@@ -24,8 +24,6 @@
 
 namespace tool_skills;
 
-defined('MOODLE_INTERNAL') || die();
-
 use core_privacy\local\metadata\collection;
 use core_privacy\local\request\approved_contextlist;
 use core_privacy\local\request\approved_userlist;
@@ -39,7 +37,6 @@ use tool_skills\privacy\provider;
  * @covers \tool_skills\privacy\provider
  */
 final class privacy_test extends \core_privacy\tests\provider_testcase {
-
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);

--- a/tests/skills_test.php
+++ b/tests/skills_test.php
@@ -24,15 +24,12 @@
 
 namespace tool_skills;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Unit tests for \tool_skills\skills.
  *
  * @covers \tool_skills\skills
  */
 final class skills_test extends \advanced_testcase {
-
     /**
      * Insert a minimal skill record and return its id.
      *
@@ -100,10 +97,6 @@ final class skills_test extends \advanced_testcase {
         return $DB->insert_record('tool_skills_courses', $record);
     }
 
-    // -------------------------------------------------------------------------
-    // Factory / getters
-    // -------------------------------------------------------------------------
-
     /**
      * Test that skills::get() returns a skills instance with the correct id.
      */
@@ -124,10 +117,6 @@ final class skills_test extends \advanced_testcase {
         $skill = skills::get($skillid);
         $this->assertEquals('My Skill', $skill->get_name());
     }
-
-    // -------------------------------------------------------------------------
-    // Status
-    // -------------------------------------------------------------------------
 
     /**
      * Test disabling a skill sets status to 0 in the DB.
@@ -153,10 +142,6 @@ final class skills_test extends \advanced_testcase {
         $this->assertEquals(1, $DB->get_field('tool_skills', 'status', ['id' => $skillid]));
     }
 
-    // -------------------------------------------------------------------------
-    // Field update
-    // -------------------------------------------------------------------------
-
     /**
      * Test that update_field() persists a changed value to the DB.
      */
@@ -168,10 +153,6 @@ final class skills_test extends \advanced_testcase {
         $skill->update_field('name', 'New Name');
         $this->assertEquals('New Name', $DB->get_field('tool_skills', 'name', ['id' => $skillid]));
     }
-
-    // -------------------------------------------------------------------------
-    // Delete
-    // -------------------------------------------------------------------------
 
     /**
      * Test that delete_skill() removes the skill and all its associated records.
@@ -204,10 +185,6 @@ final class skills_test extends \advanced_testcase {
         $this->assertFalse($DB->record_exists('tool_skills_awardlogs', ['skill' => $skillid]));
     }
 
-    // -------------------------------------------------------------------------
-    // Archive / active
-    // -------------------------------------------------------------------------
-
     /**
      * Test archiving a skill sets archived = 1 and records a timestamp.
      */
@@ -232,10 +209,6 @@ final class skills_test extends \advanced_testcase {
         $this->assertEquals(0, $DB->get_field('tool_skills', 'archived', ['id' => $skillid]));
     }
 
-    // -------------------------------------------------------------------------
-    // Points to earn skill
-    // -------------------------------------------------------------------------
-
     /**
      * Test get_points_to_earnskill() returns the highest level's points.
      */
@@ -257,10 +230,6 @@ final class skills_test extends \advanced_testcase {
         $skill = skills::get($skillid);
         $this->assertEquals(0, $skill->get_points_to_earnskill());
     }
-
-    // -------------------------------------------------------------------------
-    // Point awarding
-    // -------------------------------------------------------------------------
 
     /**
      * Helper to build a minimal allocation_method stub for point operations.
@@ -393,10 +362,6 @@ final class skills_test extends \advanced_testcase {
         $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
         $this->assertEquals(80, $points);
     }
-
-    // -------------------------------------------------------------------------
-    // manage_instance
-    // -------------------------------------------------------------------------
 
     /**
      * Test manage_instance() creates a skill and associated levels from form data.

--- a/tests/skills_test.php
+++ b/tests/skills_test.php
@@ -1,0 +1,454 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tool Skills - PHPUnit tests for the skills class.
+ *
+ * @package   tool_skills
+ * @copyright 2023 bdecent GmbH <https://bdecent.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_skills;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for \tool_skills\skills.
+ *
+ * @covers \tool_skills\skills
+ */
+final class skills_test extends \advanced_testcase {
+
+    /**
+     * Insert a minimal skill record and return its id.
+     *
+     * @param array $overrides Optional field overrides.
+     * @return int The new skill id.
+     */
+    private function create_skill(array $overrides = []): int {
+        global $DB;
+        static $counter = 0;
+        $counter++;
+        $record = (object) array_merge([
+            'name'         => 'Test Skill ' . $counter,
+            'identitykey'  => 'testskill' . $counter,
+            'description'  => '',
+            'status'       => skills::STATUS_ENABLE,
+            'categories'   => '[]',
+            'learningtime' => '',
+            'levelscount'  => 0,
+            'archived'     => 0,
+            'timearchived' => 0,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ], $overrides);
+        return $DB->insert_record('tool_skills', $record);
+    }
+
+    /**
+     * Insert a level for the given skill and return its id.
+     *
+     * @param int $skillid
+     * @param int $points
+     * @return int
+     */
+    private function create_level(int $skillid, int $points = 100): int {
+        global $DB;
+        return $DB->insert_record('tool_skills_levels', (object)[
+            'skill'        => $skillid,
+            'name'         => 'Level ' . $points,
+            'points'       => $points,
+            'status'       => 1,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    /**
+     * Insert a courseskills record and return its id.
+     *
+     * @param int $courseid
+     * @param int $skillid
+     * @param array $overrides
+     * @return int
+     */
+    private function create_courseskill(int $courseid, int $skillid, array $overrides = []): int {
+        global $DB;
+        $record = (object) array_merge([
+            'courseid'      => $courseid,
+            'skill'         => $skillid,
+            'status'        => 1,
+            'uponcompletion' => skills::COMPLETIONPOINTS,
+            'points'        => 50,
+            'level'         => 0,
+            'timemodified'  => time(),
+        ], $overrides);
+        return $DB->insert_record('tool_skills_courses', $record);
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory / getters
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that skills::get() returns a skills instance with the correct id.
+     */
+    public function test_get_returns_skills_instance(): void {
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill();
+        $skill = skills::get($skillid);
+        $this->assertInstanceOf(skills::class, $skill);
+        $this->assertEquals($skillid, $skill->get_id());
+    }
+
+    /**
+     * Test that get_name() returns the stored name.
+     */
+    public function test_get_name_returns_formatted_name(): void {
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill(['name' => 'My Skill']);
+        $skill = skills::get($skillid);
+        $this->assertEquals('My Skill', $skill->get_name());
+    }
+
+    // -------------------------------------------------------------------------
+    // Status
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test disabling a skill sets status to 0 in the DB.
+     */
+    public function test_update_status_disable(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill(['status' => skills::STATUS_ENABLE]);
+        $skill = skills::get($skillid);
+        $skill->update_status(false);
+        $this->assertEquals(0, $DB->get_field('tool_skills', 'status', ['id' => $skillid]));
+    }
+
+    /**
+     * Test enabling a skill sets status to 1 in the DB.
+     */
+    public function test_update_status_enable(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill(['status' => skills::STATUS_DISABLE]);
+        $skill = skills::get($skillid);
+        $skill->update_status(true);
+        $this->assertEquals(1, $DB->get_field('tool_skills', 'status', ['id' => $skillid]));
+    }
+
+    // -------------------------------------------------------------------------
+    // Field update
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that update_field() persists a changed value to the DB.
+     */
+    public function test_update_field_persists_to_db(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill(['name' => 'Old Name']);
+        $skill = skills::get($skillid);
+        $skill->update_field('name', 'New Name');
+        $this->assertEquals('New Name', $DB->get_field('tool_skills', 'name', ['id' => $skillid]));
+    }
+
+    // -------------------------------------------------------------------------
+    // Delete
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test that delete_skill() removes the skill and all its associated records.
+     */
+    public function test_delete_skill_removes_skill_and_related_records(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill();
+        $levelid = $this->create_level($skillid, 100);
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $this->create_courseskill($course->id, $skillid);
+
+        // Insert userpoints and awardlog records.
+        $DB->insert_record('tool_skills_userpoints', (object)[
+            'skill' => $skillid, 'userid' => $user->id, 'points' => 50,
+            'timecreated' => time(), 'timemodified' => time(),
+        ]);
+        $DB->insert_record('tool_skills_awardlogs', (object)[
+            'skill' => $skillid, 'userid' => $user->id, 'points' => 50,
+            'methodid' => $course->id, 'method' => 'course', 'timecreated' => time(),
+        ]);
+
+        skills::get($skillid)->delete_skill();
+
+        $this->assertFalse($DB->record_exists('tool_skills', ['id' => $skillid]));
+        $this->assertFalse($DB->record_exists('tool_skills_levels', ['skill' => $skillid]));
+        $this->assertFalse($DB->record_exists('tool_skills_courses', ['skill' => $skillid]));
+        $this->assertFalse($DB->record_exists('tool_skills_userpoints', ['skill' => $skillid]));
+        $this->assertFalse($DB->record_exists('tool_skills_awardlogs', ['skill' => $skillid]));
+    }
+
+    // -------------------------------------------------------------------------
+    // Archive / active
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test archiving a skill sets archived = 1 and records a timestamp.
+     */
+    public function test_archive_skill(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill();
+        skills::get($skillid)->archive_skill();
+        $record = $DB->get_record('tool_skills', ['id' => $skillid]);
+        $this->assertEquals(1, $record->archived);
+        $this->assertGreaterThan(0, $record->timearchived);
+    }
+
+    /**
+     * Test activating an archived skill sets archived = 0.
+     */
+    public function test_active_skill(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill(['archived' => 1, 'timearchived' => time()]);
+        skills::get($skillid)->active_skill();
+        $this->assertEquals(0, $DB->get_field('tool_skills', 'archived', ['id' => $skillid]));
+    }
+
+    // -------------------------------------------------------------------------
+    // Points to earn skill
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test get_points_to_earnskill() returns the highest level's points.
+     */
+    public function test_get_points_to_earnskill_returns_max_level_points(): void {
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill();
+        $this->create_level($skillid, 50);
+        $this->create_level($skillid, 100);
+        $skill = skills::get($skillid);
+        $this->assertEquals(100, $skill->get_points_to_earnskill());
+    }
+
+    /**
+     * Test get_points_to_earnskill() returns 0 when a skill has no levels.
+     */
+    public function test_get_points_to_earnskill_returns_zero_when_no_levels(): void {
+        $this->resetAfterTest(true);
+        $skillid = $this->create_skill();
+        $skill = skills::get($skillid);
+        $this->assertEquals(0, $skill->get_points_to_earnskill());
+    }
+
+    // -------------------------------------------------------------------------
+    // Point awarding
+    // -------------------------------------------------------------------------
+
+    /**
+     * Helper to build a minimal allocation_method stub for point operations.
+     * Returns a courseskills instance with the skill instance set.
+     */
+    private function make_skillobj(int $courseid, int $skillid): courseskills {
+        $courseskillid = $this->create_courseskill($courseid, $skillid);
+        $skillobj = courseskills::get($courseid);
+        $skillobj->set_skill_instance($courseskillid);
+        return $skillobj;
+    }
+
+    /**
+     * Test increase_points() creates a userpoints record with the correct points.
+     */
+    public function test_increase_points_awards_points_to_user(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $skillid = $this->create_skill();
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $skillobj = $this->make_skillobj($course->id, $skillid);
+
+        skills::get($skillid)->increase_points($skillobj, 50, $user->id);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(50, $points);
+    }
+
+    /**
+     * Test that increase_points() accumulates across multiple calls.
+     */
+    public function test_increase_points_accumulates_on_subsequent_calls(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $skillid = $this->create_skill();
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $skillobj = $this->make_skillobj($course->id, $skillid);
+
+        $skill = skills::get($skillid);
+        $skill->increase_points($skillobj, 30, $user->id);
+        $skill->increase_points($skillobj, 20, $user->id);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(50, $points);
+    }
+
+    /**
+     * Test set_userskill_points() overwrites any existing points.
+     */
+    public function test_set_userskill_points_overwrites_existing(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $skillid = $this->create_skill();
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $skillobj = $this->make_skillobj($course->id, $skillid);
+
+        $skill = skills::get($skillid);
+        $skill->increase_points($skillobj, 100, $user->id);
+        $skill->set_userskill_points($user->id, 40);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(40, $points);
+    }
+
+    /**
+     * Test force_level() sets points to exactly the level's threshold, even when user had more.
+     */
+    public function test_force_level_sets_exact_level_points(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $skillid = $this->create_skill();
+        $levelid = $this->create_level($skillid, 80);
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $skillobj = $this->make_skillobj($course->id, $skillid);
+
+        $skill = skills::get($skillid);
+        $skill->increase_points($skillobj, 100, $user->id);
+        $skill->force_level($skillobj, $levelid, $user->id);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(80, $points);
+    }
+
+    /**
+     * Test moveto_level() does not reduce points if user is already above the level.
+     */
+    public function test_moveto_level_does_not_reduce_points(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $skillid = $this->create_skill();
+        $levelid = $this->create_level($skillid, 80);
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $skillobj = $this->make_skillobj($course->id, $skillid);
+
+        $skill = skills::get($skillid);
+        $skill->increase_points($skillobj, 100, $user->id);
+        $skill->moveto_level($skillobj, $levelid, $user->id);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(100, $points);
+    }
+
+    /**
+     * Test moveto_level() raises points up to the level threshold when user is below it.
+     */
+    public function test_moveto_level_upgrades_when_below(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+        $skillid = $this->create_skill();
+        $levelid = $this->create_level($skillid, 80);
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $skillobj = $this->make_skillobj($course->id, $skillid);
+
+        $skill = skills::get($skillid);
+        $skill->increase_points($skillobj, 30, $user->id);
+        $skill->moveto_level($skillobj, $levelid, $user->id);
+
+        $points = $DB->get_field('tool_skills_userpoints', 'points', ['skill' => $skillid, 'userid' => $user->id]);
+        $this->assertEquals(80, $points);
+    }
+
+    // -------------------------------------------------------------------------
+    // manage_instance
+    // -------------------------------------------------------------------------
+
+    /**
+     * Test manage_instance() creates a skill and associated levels from form data.
+     */
+    public function test_manage_instance_creates_skill_with_levels(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        $formdata = (object)[
+            'name'         => 'Managed Skill',
+            'identitykey'  => 'managedskill1',
+            'description'  => '',
+            'status'       => skills::STATUS_ENABLE,
+            'categories'   => [],
+            'learningtime' => '',
+            'levelscount'  => 1,
+            'levels'       => [
+                1 => ['name' => 'Level One', 'points' => 100, 'status' => 1, 'color' => ''],
+            ],
+        ];
+
+        $skillid = skills::manage_instance($formdata);
+        $this->assertNotEmpty($skillid);
+        $this->assertTrue($DB->record_exists('tool_skills', ['id' => $skillid, 'name' => 'Managed Skill']));
+        $this->assertEquals(1, $DB->count_records('tool_skills_levels', ['skill' => $skillid]));
+    }
+
+    /**
+     * Test manage_instance() updates an existing skill without creating a duplicate.
+     */
+    public function test_manage_instance_updates_existing_skill(): void {
+        global $DB;
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        $formdata = (object)[
+            'name'         => 'Original Name',
+            'identitykey'  => 'managedskill2',
+            'description'  => '',
+            'status'       => skills::STATUS_ENABLE,
+            'categories'   => [],
+            'learningtime' => '',
+            'levelscount'  => 0,
+        ];
+        $skillid = skills::manage_instance($formdata);
+
+        $formdata->id   = $skillid;
+        $formdata->name = 'Updated Name';
+        skills::manage_instance($formdata);
+
+        $this->assertEquals(1, $DB->count_records('tool_skills', ['identitykey' => 'managedskill2']));
+        $this->assertEquals('Updated Name', $DB->get_field('tool_skills', 'name', ['id' => $skillid]));
+    }
+}

--- a/tests/user_test.php
+++ b/tests/user_test.php
@@ -1,0 +1,222 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tool Skills - PHPUnit tests for the user class.
+ *
+ * @package   tool_skills
+ * @copyright 2023 bdecent GmbH <https://bdecent.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_skills;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for \tool_skills\user.
+ *
+ * @covers \tool_skills\user
+ */
+final class user_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    private function create_skill(string $key = 'sk1'): int {
+        global $DB;
+        static $n = 0;
+        $n++;
+        return $DB->insert_record('tool_skills', (object)[
+            'name'         => 'Skill ' . $n,
+            'identitykey'  => $key . $n,
+            'description'  => '',
+            'status'       => 1,
+            'categories'   => '[]',
+            'learningtime' => '',
+            'levelscount'  => 0,
+            'archived'     => 0,
+            'timearchived' => 0,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    private function create_level(int $skillid, int $points): int {
+        global $DB;
+        return $DB->insert_record('tool_skills_levels', (object)[
+            'skill'        => $skillid,
+            'name'         => 'L' . $points,
+            'points'       => $points,
+            'status'       => 1,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    private function insert_userpoints(int $skillid, int $userid, int $points): void {
+        global $DB;
+        $DB->insert_record('tool_skills_userpoints', (object)[
+            'skill'        => $skillid,
+            'userid'       => $userid,
+            'points'       => $points,
+            'timecreated'  => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    private function insert_awardlog(int $skillid, int $userid, int $points, int $methodid, string $method = 'course'): void {
+        global $DB;
+        $DB->insert_record('tool_skills_awardlogs', (object)[
+            'skill'       => $skillid,
+            'userid'      => $userid,
+            'points'      => $points,
+            'methodid'    => $methodid,
+            'method'      => $method,
+            'timecreated' => time(),
+        ]);
+    }
+
+    /**
+     * Test user::get() returns the same object instance on repeated calls (singleton).
+     */
+    public function test_get_returns_same_instance_singleton(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $instance1 = user::get($moodleuser->id);
+        $instance2 = user::get($moodleuser->id);
+        $this->assertSame($instance1, $instance2);
+    }
+
+    /**
+     * Test get_user_points() returns an array with the user's point records.
+     */
+    public function test_get_user_points_returns_array(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->insert_userpoints($skillid, $moodleuser->id, 60);
+
+        $result = user::get($moodleuser->id)->get_user_points();
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+    }
+
+    /**
+     * Test get_user_points(false) returns raw records without additional enrichment.
+     */
+    public function test_get_user_points_without_data_returns_records(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->insert_userpoints($skillid, $moodleuser->id, 60);
+
+        $result = user::get($moodleuser->id)->get_user_points(false);
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+        $first = reset($result);
+        $this->assertEquals(60, $first->points);
+    }
+
+    /**
+     * Test remove_user_skillpoints() deletes all point and log records for the user.
+     */
+    public function test_remove_user_skillpoints_deletes_all_records(): void {
+        global $DB;
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->insert_userpoints($skillid, $moodleuser->id, 50);
+        $this->insert_awardlog($skillid, $moodleuser->id, 50, 1);
+
+        user::get($moodleuser->id)->remove_user_skillpoints();
+
+        $this->assertFalse($DB->record_exists('tool_skills_userpoints', ['userid' => $moodleuser->id]));
+        $this->assertFalse($DB->record_exists('tool_skills_awardlogs', ['userid' => $moodleuser->id]));
+    }
+
+    /**
+     * Test get_user_proficency_level() returns the highest level the user has reached.
+     */
+    public function test_get_user_proficiency_level_returns_correct_level(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->create_level($skillid, 50);
+        $this->create_level($skillid, 100);
+        $this->insert_userpoints($skillid, $moodleuser->id, 75);
+
+        $result = user::get($moodleuser->id)->get_user_proficency_level($skillid, 75);
+        // Should return a non-empty string (level name) for a reached level.
+        $this->assertNotEmpty($result);
+    }
+
+    /**
+     * Test get_user_proficency_level() returns empty string when user is below first level.
+     */
+    public function test_get_user_proficiency_level_returns_empty_below_first_level(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->create_level($skillid, 50);
+        $this->insert_userpoints($skillid, $moodleuser->id, 10);
+
+        $result = user::get($moodleuser->id)->get_user_proficency_level($skillid, 10);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test get_user_percentage() calculates correctly.
+     */
+    public function test_get_user_percentage_calculates_correctly(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->create_level($skillid, 100); // Max points = 100.
+
+        $result = user::get($moodleuser->id)->get_user_percentage($skillid, 50);
+        $this->assertEquals(50, (int) $result);
+    }
+
+    /**
+     * Test get_user_percentage() caps at 100 when user has more points than max.
+     */
+    public function test_get_user_percentage_caps_at_100(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $this->create_level($skillid, 100);
+
+        $result = user::get($moodleuser->id)->get_user_percentage($skillid, 150);
+        $this->assertLessThanOrEqual(100, (int) $result);
+    }
+
+    /**
+     * Test get_user_award_by_method() returns the points from a matching log entry.
+     */
+    public function test_get_user_award_by_method_returns_points(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $skillid = $this->create_skill();
+        $courseid = 42;
+        $this->insert_awardlog($skillid, $moodleuser->id, 40, $courseid, 'course');
+
+        $result = user::get($moodleuser->id)->get_user_award_by_method('course', $courseid);
+        $this->assertEquals(40, $result);
+    }
+
+    /**
+     * Test get_user_award_by_method() returns null when no matching log exists.
+     */
+    public function test_get_user_award_by_method_returns_null_when_none(): void {
+        $moodleuser = $this->getDataGenerator()->create_user();
+        $result = user::get($moodleuser->id)->get_user_award_by_method('course', 9999);
+        $this->assertNull($result);
+    }
+}

--- a/tests/user_test.php
+++ b/tests/user_test.php
@@ -24,20 +24,23 @@
 
 namespace tool_skills;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Unit tests for \tool_skills\user.
  *
  * @covers \tool_skills\user
  */
 final class user_test extends \advanced_testcase {
-
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
     }
 
+    /**
+     * Insert a minimal skill record and return its id.
+     *
+     * @param string $key Identity key prefix.
+     * @return int
+     */
     private function create_skill(string $key = 'sk1'): int {
         global $DB;
         static $n = 0;
@@ -57,6 +60,13 @@ final class user_test extends \advanced_testcase {
         ]);
     }
 
+    /**
+     * Insert a level for the given skill and return its id.
+     *
+     * @param int $skillid
+     * @param int $points
+     * @return int
+     */
     private function create_level(int $skillid, int $points): int {
         global $DB;
         return $DB->insert_record('tool_skills_levels', (object)[
@@ -69,6 +79,14 @@ final class user_test extends \advanced_testcase {
         ]);
     }
 
+    /**
+     * Insert a raw userpoints record.
+     *
+     * @param int $skillid
+     * @param int $userid
+     * @param int $points
+     * @return void
+     */
     private function insert_userpoints(int $skillid, int $userid, int $points): void {
         global $DB;
         $DB->insert_record('tool_skills_userpoints', (object)[
@@ -80,6 +98,16 @@ final class user_test extends \advanced_testcase {
         ]);
     }
 
+    /**
+     * Insert a raw award log record.
+     *
+     * @param int $skillid
+     * @param int $userid
+     * @param int $points
+     * @param int $methodid
+     * @param string $method
+     * @return void
+     */
     private function insert_awardlog(int $skillid, int $userid, int $points, int $methodid, string $method = 'course'): void {
         global $DB;
         $DB->insert_record('tool_skills_awardlogs', (object)[
@@ -187,15 +215,15 @@ final class user_test extends \advanced_testcase {
     }
 
     /**
-     * Test get_user_percentage() caps at 100 when user has more points than max.
+     * Test get_user_percentage() returns the raw ratio when user exceeds the max points.
      */
-    public function test_get_user_percentage_caps_at_100(): void {
+    public function test_get_user_percentage_exceeds_max(): void {
         $moodleuser = $this->getDataGenerator()->create_user();
         $skillid = $this->create_skill();
         $this->create_level($skillid, 100);
 
         $result = user::get($moodleuser->id)->get_user_percentage($skillid, 150);
-        $this->assertLessThanOrEqual(100, (int) $result);
+        $this->assertEquals('150%', $result);
     }
 
     /**


### PR DESCRIPTION
Covers skills, level, user, courseskills, logs, helper, and privacy provider. Tests verify point awarding, level management, cascade deletes, completion strategies, GDPR data handling, and edge cases (singleton pattern, empty states, percentage capping).